### PR TITLE
CI Revamp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        # TODO: Include 22 and 23 when https://github.com/yeoman/yeoman-welcome/issues/7 is fixed
+        node: [8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]
+        exclude:
+          # Avoid Error: Unable to find Node versions for platform darwin and architecture arm64: 
+          # @SEE: https://github.com/yeoman/yeoman-welcome/actions/runs/12846318454/job/35821411749?pr=6
+          - os: macos-latest
+            node: 8
+          - os: macos-latest
+            node: 9
+          - os: macos-latest
+            node: 10
+          - os: macos-latest
+            node: 11
+          - os: macos-latest
+            node: 12
+          - os: macos-latest
+            node: 13
+          - os: macos-latest
+            node: 14
+          - os: macos-latest
+            node: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: node_js
-node_js:
-  - node
-  - 10
-  - 8

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# yeoman-welcome [![Build Status](https://travis-ci.org/yeoman/yeoman-welcome.svg?branch=master)](https://travis-ci.org/yeoman/yeoman-welcome)
+# yeoman-welcome [![CI](https://github.com/yeoman/yeoman-welcome/actions/workflows/ci.yml/badge.svg)](https://github.com/yeoman/yeoman-welcome/actions/workflows/ci.yml)
 
 > Yeoman welcome message used in generators
 


### PR DESCRIPTION
### Main Changes

Migration from Travis to GitHub Actions (b85a521), also engine versions are now updated with a known limitation for Node@22 and Node@23 ([see](https://github.com/yeoman/yeoman-welcome/issues/7))

### Changelog

- 66365db ci: remove travis by @UlisesGascon
- b85a521 ci: add GitHub Actions pipeline by @UlisesGascon
- d0301db docs: replace build sticker by @UlisesGascon